### PR TITLE
Update AccessTokenEntity.php

### DIFF
--- a/src/AccessToken/AccessTokenEntity.php
+++ b/src/AccessToken/AccessTokenEntity.php
@@ -103,7 +103,7 @@ class AccessTokenEntity implements AccessTokenEntityInterface
 		return $this->expiryDateTime;
 	}
 
-	public function getUserIdentifier(): string
+	public function getUserIdentifier(): ?string
 	{
 		return $this->userIdentifier;
 	}


### PR DESCRIPTION
When using Client credentials grant AccessTokenEntity::getUserIdentifier() is null and return type null is not allowed, but it should be.