### PR TITLE
Do not force string as return type of getUserIdentifier method

### DIFF
--- a/src/AccessToken/AccessTokenEntity.php
+++ b/src/AccessToken/AccessTokenEntity.php
@@ -103,6 +103,9 @@ class AccessTokenEntity implements AccessTokenEntityInterface
 		return $this->expiryDateTime;
 	}
 
+	/**
+	 * @return int|string|null
+	 */
 	public function getUserIdentifier()
 	{
 		return $this->userIdentifier;

--- a/src/AccessToken/AccessTokenEntity.php
+++ b/src/AccessToken/AccessTokenEntity.php
@@ -103,7 +103,7 @@ class AccessTokenEntity implements AccessTokenEntityInterface
 		return $this->expiryDateTime;
 	}
 
-	public function getUserIdentifier(): ?string
+	public function getUserIdentifier()
 	{
 		return $this->userIdentifier;
 	}

--- a/src/AuthCode/AuthCodeEntity.php
+++ b/src/AuthCode/AuthCodeEntity.php
@@ -143,7 +143,7 @@ class AuthCodeEntity implements AuthCodeEntityInterface
 		$this->userIdentifier = $identifier;
 	}
 
-	public function getUserIdentifier(): string
+	public function getUserIdentifier()
 	{
 		return $this->userIdentifier;
 	}

--- a/src/AuthCode/AuthCodeEntity.php
+++ b/src/AuthCode/AuthCodeEntity.php
@@ -143,6 +143,9 @@ class AuthCodeEntity implements AuthCodeEntityInterface
 		$this->userIdentifier = $identifier;
 	}
 
+	/**
+	 * @return int|string|null
+	 */
 	public function getUserIdentifier()
 	{
 		return $this->userIdentifier;


### PR DESCRIPTION
We use majkl578/nette-identity-doctrine and identity->getId() returns int instead of string and thus method getUserIdentifier fails, because it expects string as return type.

I have inspected implemented interfaces and they expects string|int|null as return value, so I think forcing string as return type is not a good idea.